### PR TITLE
[FEAT] 사용자 주문 데이터 메세지 큐로 처리하기

### DIFF
--- a/mooney/build.gradle
+++ b/mooney/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     testImplementation platform('org.junit:junit-bom:5.9.1')
     testImplementation 'org.junit.jupiter:junit-jupiter'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
+    //implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
@@ -40,13 +40,16 @@ dependencies {
     implementation 'mysql:mysql-connector-java:8.0.33'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.security:spring-security-test'
+    //testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // WebSocket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'javax.websocket:javax.websocket-api:1.1'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
+
+    // Kafka
+    implementation 'org.springframework.kafka:spring-kafka'
 }
 
 test {

--- a/mooney/src/main/java/org/example/controller/OfferController.java
+++ b/mooney/src/main/java/org/example/controller/OfferController.java
@@ -1,0 +1,28 @@
+package org.example.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.dto.OfferDto;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/offer")
+@RequiredArgsConstructor
+public class OfferController {
+
+    private final KafkaTemplate<String, OfferDto> kafkaTemplate;
+
+    @PostMapping()
+    public void offerStock(@ModelAttribute OfferDto dto) {
+        // @ModelAttribute → Thymeleaf 폼 데이터를 DTO로 자동 매핑
+        // DTO의 필드와 폼 input name이 일치하면 자동 매핑
+        kafkaTemplate.send("order-request", dto);
+        System.out.println("📤 메세지 발행 : " + dto.getStockCode() + " " +
+                dto.getOfferPrice() + " " +
+                dto.getOfferCnt() + " " +
+                dto.getOfferSide());
+    }
+}

--- a/mooney/src/main/java/org/example/dto/OfferDto.java
+++ b/mooney/src/main/java/org/example/dto/OfferDto.java
@@ -1,0 +1,19 @@
+package org.example.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class OfferDto {
+    // 종목코드
+    private String stockCode;
+    // 호가 (주문가)
+    private int offerPrice;
+    // 주문량
+    private int offerCnt;
+    // 매도 or 매수 여부
+    private String offerSide;
+}

--- a/mooney/src/main/java/org/example/dto/OfferDto.java
+++ b/mooney/src/main/java/org/example/dto/OfferDto.java
@@ -1,8 +1,13 @@
 package org.example.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.example.entity.Account;
+import org.example.entity.Offer;
+import org.example.entity.Stock;
+import org.example.entity.Trade;
 
 @Getter
 @Setter
@@ -16,4 +21,23 @@ public class OfferDto {
     private int offerCnt;
     // 매도 or 매수 여부
     private String offerSide;
+
+    @Builder(builderMethodName = "offerBuilder")
+    public Offer toEntity(OfferDto dto, Stock stock, Account account) {
+        return Offer.builder()
+                .stock(stock)
+                .offerPrice(dto.getOfferPrice())
+                .offerCnt(dto.getOfferCnt())
+                .offerSide(dto.getOfferSide())
+                .offerStatus("PENDING")
+                .account(account)
+                .build();
+    }
+
+    @Builder(builderMethodName = "tradeBuilder")
+    public Trade addTradeEntity(Offer offer) {
+        return Trade.builder()
+                .offer(offer)
+                .build();
+    }
 }

--- a/mooney/src/main/java/org/example/repository/AccountRepository.java
+++ b/mooney/src/main/java/org/example/repository/AccountRepository.java
@@ -1,0 +1,11 @@
+package org.example.repository;
+
+import org.example.entity.Account;
+import org.example.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AccountRepository extends JpaRepository<Account, Long> {
+    Account findByUser(Optional<User> user);
+}

--- a/mooney/src/main/java/org/example/repository/StockRepository.java
+++ b/mooney/src/main/java/org/example/repository/StockRepository.java
@@ -3,5 +3,6 @@ package org.example.repository;
 import org.example.entity.Stock;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface StockRepository extends JpaRepository<Stock, String> {
+public interface StockRepository extends JpaRepository<Stock, Long> {
+    Stock findByStockCode(String stockCode);
 }

--- a/mooney/src/main/java/org/example/repository/UserRepository.java
+++ b/mooney/src/main/java/org/example/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package org.example.repository;
+
+import org.example.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findById(Long userId);
+}

--- a/mooney/src/main/java/org/example/service/OfferKafkaConsumer.java
+++ b/mooney/src/main/java/org/example/service/OfferKafkaConsumer.java
@@ -1,0 +1,47 @@
+package org.example.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.dto.OfferDto;
+import org.example.entity.Account;
+import org.example.entity.Offer;
+import org.example.entity.Stock;
+import org.example.entity.User;
+import org.example.repository.*;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class OfferKafkaConsumer {
+
+    private final StockRepository stockRepository;
+    private final AccountRepository accountRepository;
+    private final UserRepository userRepository;
+    private final OfferRepository offerRepository;
+    private final TradeRepository tradeRepository;
+
+    @Transactional
+    @KafkaListener(topics = "order-request", groupId = "mooney-offer-group")
+    public void saveOffer(OfferDto dto) {
+        System.out.println("📥 메세지 구독 : " + dto.getStockCode() + " " +
+                dto.getOfferPrice() + " " +
+                dto.getOfferCnt() + " " +
+                dto.getOfferSide());
+
+        // Stock, Account 데이터 조회
+        Stock stock = stockRepository.findByStockCode(dto.getStockCode());
+        Optional<User> user = userRepository.findById(1L);
+        Account account = accountRepository.findByUser(user);
+
+        // 1. 주문 테이블에 저장
+        Offer offer = dto.toEntity(dto, stock, account);
+        offerRepository.save(offer);
+
+        // 2. 체결 테이블에 저장 (PENDING 상태)
+        tradeRepository.save(dto.addTradeEntity(offer));
+    }
+}

--- a/mooney/src/main/resources/kafka-compose.yml
+++ b/mooney/src/main/resources/kafka-compose.yml
@@ -1,0 +1,110 @@
+version: '3'
+
+networks:
+  kafka_network:
+
+volumes:
+  Kafka00:
+    driver: local
+  Kafka01:
+    driver: local
+  Kafka02:
+    driver: local
+
+services:
+  mooney-broker01:
+    image: bitnami/kafka:3.5.1-debian-11-r44
+    restart: unless-stopped
+    container_name: mooney-broker01
+    ports:
+      - '10000:9094'
+    environment:
+      - KAFKA_CFG_BROKER_ID=0
+      - KAFKA_CFG_NODE_ID=0
+      - KAFKA_KRAFT_CLUSTER_ID=HsDBs9l6UUmQq7Y5E6bNlw
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@mooney-broker01:9093,1@mooney-broker02:9093,2@mooney-broker03:9093
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:9094
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://mooney-broker01:9092,EXTERNAL://127.0.0.1:10000
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      - KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR=3
+      - KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=3
+      - KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR=2
+      - KAFKA_CFG_PROCESS_ROLES=controller,broker
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+    networks:
+      - kafka_network
+    volumes:
+      - Kafka00:/bitnami/kafka
+
+  mooney-broker02:
+    image: bitnami/kafka:3.5.1-debian-11-r44
+    restart: unless-stopped
+    container_name: mooney-broker02
+    ports:
+      - '10001:9094'
+    environment:
+      - KAFKA_CFG_BROKER_ID=1
+      - KAFKA_CFG_NODE_ID=1
+      - KAFKA_KRAFT_CLUSTER_ID=HsDBs9l6UUmQq7Y5E6bNlw
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@mooney-broker01:9093,1@mooney-broker02:9093,2@mooney-broker03:9093
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:9094
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://mooney-broker02:9092,EXTERNAL://127.0.0.1:10001
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      - KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR=3
+      - KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=3
+      - KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR=2
+      - KAFKA_CFG_PROCESS_ROLES=controller,broker
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+    networks:
+      - kafka_network
+    volumes:
+      - Kafka01:/bitnami/kafka
+
+  mooney-broker03:
+    image: bitnami/kafka:3.5.1-debian-11-r44
+    restart: unless-stopped
+    container_name: mooney-broker03
+    ports:
+      - '10002:9094'
+    environment:
+      - KAFKA_CFG_BROKER_ID=2
+      - KAFKA_CFG_NODE_ID=2
+      - KAFKA_KRAFT_CLUSTER_ID=HsDBs9l6UUmQq7Y5E6bNlw
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@mooney-broker01:9093,1@mooney-broker02:9093,2@mooney-broker03:9093
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:9094
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://mooney-broker03:9092,EXTERNAL://127.0.0.1:10002
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      - KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR=3
+      - KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=3
+      - KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR=2
+      - KAFKA_CFG_PROCESS_ROLES=controller,broker
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+    networks:
+      - kafka_network
+    volumes:
+      - Kafka02:/bitnami/kafka
+
+  KafkaWebUiService:
+    image: provectuslabs/kafka-ui:latest
+    restart: always
+    container_name: mooney-broker-ui
+    ports:
+      - '8085:8080' # 호스트의 8085 포트를 컨테이너의 8080 포트에 바인딩
+    environment:
+      - KAFKA_CLUSTERS_0_NAME=Local-Kraft-Cluster
+      - KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS=mooney-broker01:9092,mooney-broker02:9092,mooney-broker03:9092
+      - DYNAMIC_CONFIG_ENABLED=true
+      - KAFKA_CLUSTERS_0_AUDIT_TOPICAUDITENABLED=true
+      - KAFKA_CLUSTERS_0_AUDIT_CONSOLEAUDITENABLED=true
+    depends_on:
+      - mooney-broker01
+      - mooney-broker02
+      - mooney-broker03
+    networks:
+      - kafka_network


### PR DESCRIPTION
## 📎 작업 목록
1. kafka-compose.yml
2. 타임리프 폼 데이터 -> 컨트롤러 : 주문 데이터 받기
3. 컨트롤러 -> 카프카 : 주문 데이터 메세지 큐에 전송
4. 카프카 -> 컨트롤러 : 토픽 기반으로 메세지 큐에서 구독 서버에 전송
5. 컨트롤러 -> 데이터베이스 : 주문/체결 데이터 저장

https://www.notion.so/Kafka-Spring-Boot-274860fb55ab80db9f1fc5f46ea2641b